### PR TITLE
ENG-157 add yarn variant of sonarscan workflow

### DIFF
--- a/.github/workflows/yarnSonarscan.yaml
+++ b/.github/workflows/yarnSonarscan.yaml
@@ -1,0 +1,32 @@
+name: Sonarscan
+on:
+  workflow_call:
+    secrets:
+      sonar_token:
+        required: true
+      fin3_github_token:
+        required: true
+jobs:
+  sonarcloud:
+    name: CodeScan (Sonar Cloud)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+
+      - name: Node install dependencies
+        run: yarn install --immutable --immutable-cache --check-cache
+
+      - name: Run unit tests
+        run: yarn test
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.fin3_github_token }}
+          SONAR_TOKEN: ${{ secrets.sonar_token }}


### PR DESCRIPTION
Adding a workflow that can be used in Fin3 repositories to run Sonarscan on node projects built with yarn.