### PR TITLE
ENG-220: Added major minor version tags in container images

### DIFF
--- a/.github/workflows/containerBuildAndPublish.yaml
+++ b/.github/workflows/containerBuildAndPublish.yaml
@@ -40,7 +40,11 @@ jobs:
           then
             echo "final_tag=latest" >> $GITHUB_ENV
           else
+            final_majortag=`echo ${{inputs.tag}} | awk -F\. '{print $1".x"}'`
+            final_minortag=`echo ${{inputs.tag}} | awk -F\. '{print $1"."$2".x"}'`
             echo "final_tag=${{inputs.tag}}" >> $GITHUB_ENV
+            echo "final_majortag=$final_majortag" >> $GITHUB_ENV
+            echo "final_minortag=$final_minortag" >> $GITHUB_ENV
           fi
 
       - name: Set up Docker Buildx
@@ -61,7 +65,7 @@ jobs:
           file: Dockerfile
           context: .
           push: true
-          tags: fin3technologies/${{ inputs.image_name }}:${{ env.final_tag }}
+          tags: fin3technologies/${{ inputs.image_name }}:${{ env.final_tag }},fin3technologies/${{ inputs.image_name }}:${{ env.final_majortag }},fin3technologies/${{ inputs.image_name }}:${{ env.final_minortag }},fin3technologies/${{ inputs.image_name }}:latest
 
       - name: cosign-installer
         uses: Fin3-Technologies-Inc/gh-action-cosign-installer@main

--- a/.github/workflows/gradleBuildAndPublish.yaml
+++ b/.github/workflows/gradleBuildAndPublish.yaml
@@ -62,7 +62,11 @@ jobs:
           then
             echo "final_tag=latest" >> $GITHUB_ENV
           else
+            final_majortag=`echo ${{inputs.tag}} | awk -F\. '{print $1".x"}'`
+            final_minortag=`echo ${{inputs.tag}} | awk -F\. '{print $1"."$2".x"}'`
             echo "final_tag=${{inputs.tag}}" >> $GITHUB_ENV
+            echo "final_majortag=$final_majortag" >> $GITHUB_ENV
+            echo "final_minortag=$final_minortag" >> $GITHUB_ENV
           fi
 
       - name: Set up Docker Buildx
@@ -89,7 +93,7 @@ jobs:
           file: docker/Dockerfile-service
           context: .
           push: true
-          tags: fin3technologies/${{ inputs.image_name }}:${{ env.final_tag }}
+          tags: fin3technologies/${{ inputs.image_name }}:${{ env.final_tag }},fin3technologies/${{ inputs.image_name }}:${{ env.final_majortag }},fin3technologies/${{ inputs.image_name }}:${{ env.final_minortag }},fin3technologies/${{ inputs.image_name }}:latest
 
       - name: cosign-installer
         uses: Fin3-Technologies-Inc/gh-action-cosign-installer@main

--- a/.github/workflows/mvnBuildAndPublish.yaml
+++ b/.github/workflows/mvnBuildAndPublish.yaml
@@ -77,7 +77,11 @@ jobs:
           then
             echo "final_tag=latest" >> $GITHUB_ENV
           else
+            final_majortag=`echo ${{inputs.tag}} | awk -F\. '{print $1".x"}'`
+            final_minortag=`echo ${{inputs.tag}} | awk -F\. '{print $1"."$2".x"}'`
             echo "final_tag=${{inputs.tag}}" >> $GITHUB_ENV
+            echo "final_majortag=$final_majortag" >> $GITHUB_ENV
+            echo "final_minortag=$final_minortag" >> $GITHUB_ENV
           fi
 
       - name: Set up Docker Buildx
@@ -104,7 +108,7 @@ jobs:
           file: docker/Dockerfile-service
           context: .
           push: true
-          tags: fin3technologies/${{ inputs.image_name }}:${{ env.final_tag }}
+          tags: fin3technologies/${{ inputs.image_name }}:${{ env.final_tag }},fin3technologies/${{ inputs.image_name }}:${{ env.final_majortag }},fin3technologies/${{ inputs.image_name }}:${{ env.final_minortag }},fin3technologies/${{ inputs.image_name }}:latest
 
       - name: cosign-installer
         uses: Fin3-Technologies-Inc/gh-action-cosign-installer@main

--- a/.github/workflows/nodejsBuildAndPublish.yaml
+++ b/.github/workflows/nodejsBuildAndPublish.yaml
@@ -35,7 +35,11 @@ jobs:
           then
             echo "final_tag=latest" >> $GITHUB_ENV
           else
+            final_majortag=`echo ${{inputs.tag}} | awk -F\. '{print $1".x"}'`
+            final_minortag=`echo ${{inputs.tag}} | awk -F\. '{print $1"."$2".x"}'`
             echo "final_tag=${{inputs.tag}}" >> $GITHUB_ENV
+            echo "final_majortag=$final_majortag" >> $GITHUB_ENV
+            echo "final_minortag=$final_minortag" >> $GITHUB_ENV
           fi
 
       - name: Set up Docker Buildx
@@ -69,7 +73,7 @@ jobs:
           file: Dockerfile
           context: .
           push: true
-          tags: fin3technologies/${{ inputs.image_name }}:${{ env.final_tag }}
+          tags: fin3technologies/${{ inputs.image_name }}:${{ env.final_tag }},fin3technologies/${{ inputs.image_name }}:${{ env.final_majortag }},fin3technologies/${{ inputs.image_name }}:${{ env.final_minortag }},fin3technologies/${{ inputs.image_name }}:latest
 
       - name: cosign-installer
         uses: Fin3-Technologies-Inc/gh-action-cosign-installer@main


### PR DESCRIPTION
Added tagging version to the container images. 

For each latest container image build, there will be total 4 images tags for ref.

1. latest
2. v(number).x
3. v(number).(number).x
4. v(number).(number).(number) ## actual version number as per release and tag.

We can reference provided tag number in helm chart to pull latest major/minor updated version number. 