### PR TITLE
ENG-415 : Setting jvmargs in gradle.properties to avoid memory errors

### DIFF
--- a/.github/workflows/gradleSonarscan.yaml
+++ b/.github/workflows/gradleSonarscan.yaml
@@ -48,9 +48,7 @@ jobs:
       - name: Execute Gradle build
         env:
           GITHUB_TOKEN: ${{ secrets.fin3_github_token }}
-        run: |
-          cat ~/.gradle/gradle.properties
-          ./gradlew build -x test
+        run: ./gradlew build -x test
 
       - name: Test and SonarCloud Scan
         env:

--- a/.github/workflows/gradleSonarscan.yaml
+++ b/.github/workflows/gradleSonarscan.yaml
@@ -35,11 +35,22 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+
+      - name: Restore gradle.properties
+        env:
+          GRADLE_PROPERTIES: org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=128m
+        shell: bash
+        run: |
+          mkdir -p ~/.gradle/
+          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
+          echo "${GRADLE_PROPERTIES}" > ~/.gradle/gradle.properties
       
       - name: Execute Gradle build
         env:
           GITHUB_TOKEN: ${{ secrets.fin3_github_token }}
-        run: ./gradlew build -x test
+        run: |
+          cat ~/.gradle/gradle.properties
+          ./gradlew build -x test
 
       - name: Test and SonarCloud Scan
         env:


### PR DESCRIPTION
- Setting jvmargs in gradle.properties to avoid memory errors
- We were getting java heap error during sonarqube task of gradle build . So need to tweak jvm memory settting.
See failing job : https://github.com/Fin3-Technologies-Inc/hosted-node-orchestration-service/runs/7147196502?check_suite_focus=true